### PR TITLE
オブジェクト指向版 lsコマンド作成

### DIFF
--- a/08.ls_object/ls.rb
+++ b/08.ls_object/ls.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require 'optparse'
+require 'etc'
+
+module LS
+  class File
+    attr_reader :files
+
+    def initialize
+      @files = Dir.glob('*').sort
+    end
+
+    def all(files)
+      Dir.glob('.*').sort + files
+    end
+
+    def reverse(files)
+      files.reverse
+    end
+
+    def data(files)
+      fdata = []
+      files.each do |fname|
+        fstat = ::File::Stat.new(fname)
+        fdata.push [
+          permission_convert(fstat),
+          fstat.nlink.to_s.rjust(nlink_length(files)),
+          Etc.getpwuid(fstat.uid).name,
+          Etc.getgrgid(fstat.gid).name.rjust(6),
+          fstat.size.to_s.rjust(5),
+          fstat.mtime.strftime('%_m %e %H:%M'),
+          fname
+        ]
+      end
+      fdata
+    end
+
+    private
+
+    def nlink_length(files)
+      max_length = []
+      files.each do |fname|
+        fstat = ::File::Stat.new(fname)
+        max_length << fstat.nlink
+      end
+      max_length.max_by { |num| num.to_s.length }.to_s.length
+    end
+
+    def permission_convert(fstat)
+      type = fstat.ftype == 'file' ? '-' : fstat.ftype[0]
+      rwx = { '0' => '---', '1' => '--x', '2' => '-w-', '3' => '-wx',
+              '4' => 'r--', '5' => 'r-x', '6' => 'rw-', '7' => 'rwx' }
+      mode = fstat.mode.to_s(8)[-3, 3].gsub(/\d/, rwx)
+      "#{type}#{mode} "
+    end
+  end
+
+  class Command < File
+    attr_reader :options, :files
+
+    def initialize
+      super
+      @options = {}
+      opt = OptionParser.new
+      opt.on('-a', '--all') { |v| @options[:a] = v }
+      opt.on('-l', '--long') { |v| @options[:l] = v }
+      opt.on('-r', '--reverse') { |v| @options[:r] = v }
+      opt.parse(ARGV)
+    end
+
+    def select_option
+      if options[:a] == true
+        @files = all(files)
+      else
+        @files
+      end
+
+      @files = reverse(files) if options[:r] == true
+
+      if options[:l] == true
+        LS::VerticalFormatter.new.single_column(@files)
+      else
+        LS::HorizontalFormatter.new.multi_column(@files)
+      end
+    end
+  end
+
+  class HorizontalFormatter
+    def multi_column(files)
+      result = []
+      files.map { |fname| result << fname.to_s.ljust(24, ' ') }
+      format = result.each_slice(length(files)).to_a
+      push_nil(format).transpose.each { |a| puts a.join('') }
+    end
+
+    private
+
+    def length(files)
+      (files.length % 4).zero? ? files.length / 4 : files.length / 4 + 1
+    end
+
+    def push_nil(format)
+      max = format.max_by(&:length).length
+      format.each { |a| a[max - 1] = nil if a.length < max }
+    end
+  end
+
+  class VerticalFormatter
+    def total(files)
+      total = 0
+      files.each do |fname|
+        fstat = ::File::Stat.new(fname)
+        total += fstat.blocks
+      end
+      puts "total #{total}"
+    end
+
+    def single_column(files)
+      total(files)
+      fdata = LS::Command.new.data(files)
+      fdata.map { |a| puts a.each_slice(7).to_a.join(' ') }
+    end
+  end
+end
+
+LS::Command.new.select_option

--- a/08.ls_object/ls.rb
+++ b/08.ls_object/ls.rb
@@ -94,16 +94,14 @@ module Ls
 
   class VerticalFormatter
     def total(files)
-      total = 0
-      files.each do |file_name|
+      files.sum do |file_name|
         file_stat = ::File::Stat.new(file_name)
-        total += file_stat.blocks
+        file_stat.blocks
       end
-      "total #{total}"
     end
 
     def output_single_column(files)
-      puts total(files)
+      puts "total #{total(files)}"
       file_data = Ls::Command.new.data(files)
       file_data.map { |array| puts array.each_slice(7).to_a.join(' ') }
     end

--- a/08.ls_object/ls.rb
+++ b/08.ls_object/ls.rb
@@ -3,7 +3,7 @@
 require 'optparse'
 require 'etc'
 
-module LS
+module Ls
   class File
     attr_reader :files
 

--- a/08.ls_object/ls.rb
+++ b/08.ls_object/ls.rb
@@ -79,9 +79,9 @@ module Ls
       @files = reverse(files) if options[:r] == true
 
       if options[:l] == true
-        LS::VerticalFormatter.new.single_column(@files)
+        Ls::VerticalFormatter.new.single_column(@files)
       else
-        LS::HorizontalFormatter.new.multi_column(@files)
+        Ls::HorizontalFormatter.new.multi_column(@files)
       end
     end
   end
@@ -118,10 +118,10 @@ module Ls
 
     def single_column(files)
       total(files)
-      file_data = LS::Command.new.data(files)
+      file_data = Ls::Command.new.data(files)
       file_data.map { |array| puts array.each_slice(7).to_a.join(' ') }
     end
   end
 end
 
-LS::Command.new.select_option
+Ls::Command.new.select_option

--- a/08.ls_object/ls.rb
+++ b/08.ls_object/ls.rb
@@ -31,27 +31,29 @@ module Ls
       if options[:l]
         Ls::VerticalFormatter.output_single_column(@files)
       else
-        Ls::HorizontalFormatter.new.output_multi_column(@files)
+        Ls::HorizontalFormatter.output_multi_column(@files)
       end
     end
   end
 
   class HorizontalFormatter
-    def output_multi_column(files)
-      results = files.map { |file| file.to_s.ljust(24, ' ') }
-      file_names = results.each_slice(length(files)).to_a
-      push_nil(file_names).transpose.each { |array| puts array.join('') }
-    end
+    class << self
+      def output_multi_column(files)
+        results = files.map { |file| file.to_s.ljust(24, ' ') }
+        file_names = results.each_slice(length(files)).to_a
+        push_nil(file_names).transpose.each { |array| puts array.join('') }
+      end
 
-    private
+      private
 
-    def length(files)
-      (files.length % 4).zero? ? files.length / 4 : files.length / 4 + 1
-    end
+      def length(files)
+        (files.length % 4).zero? ? files.length / 4 : files.length / 4 + 1
+      end
 
-    def push_nil(format)
-      max = format.max_by(&:length).length
-      format.each { |array| array[max - 1] = nil if array.length < max }
+      def push_nil(format)
+        max = format.max_by(&:length).length
+        format.each { |array| array[max - 1] = nil if array.length < max }
+      end
     end
   end
 

--- a/08.ls_object/ls.rb
+++ b/08.ls_object/ls.rb
@@ -29,7 +29,7 @@ module Ls
       @files = all_files if options[:a]
       @files = reverse_files if options[:r]
       if options[:l]
-        Ls::VerticalFormatter.new.output_single_column(@files)
+        Ls::VerticalFormatter.output_single_column(@files)
       else
         Ls::HorizontalFormatter.new.output_multi_column(@files)
       end
@@ -56,19 +56,19 @@ module Ls
   end
 
   class VerticalFormatter
-    def total(files)
+    def self.output_single_column(files)
+      puts "total #{total(files)}"
+      file_details(files).each { |array| puts array.each_slice(7).to_a.join(' ') }
+    end
+
+    def self.total(files)
       files.sum do |file_name|
         file_stat = ::File::Stat.new(file_name)
         file_stat.blocks
       end
     end
 
-    def output_single_column(files)
-      puts "total #{total(files)}"
-      file_details(files).each { |array| puts array.each_slice(7).to_a.join(' ') }
-    end
-
-    def file_details(files)
+    def self.file_details(files)
       files.map do |file_name|
         file_stat = ::File::Stat.new(file_name)
         [
@@ -83,7 +83,7 @@ module Ls
       end
     end
 
-    def nlink_length(files)
+    def self.nlink_length(files)
       max_length = files.map do |file_name|
         file_stat = ::File::Stat.new(file_name)
         file_stat.nlink
@@ -91,7 +91,7 @@ module Ls
       max_length.max_by { |number| number.to_s.length }.to_s.length
     end
 
-    def permission_convert(file_stat)
+    def self.permission_convert(file_stat)
       type = file_stat.ftype == 'file' ? '-' : file_stat.ftype[0]
       rwx = { '0' => '---', '1' => '--x', '2' => '-w-', '3' => '-wx',
               '4' => 'r--', '5' => 'r-x', '6' => 'rw-', '7' => 'rwx' }

--- a/08.ls_object/ls.rb
+++ b/08.ls_object/ls.rb
@@ -20,38 +20,38 @@ module LS
     end
 
     def data(files)
-      fdata = []
-      files.each do |fname|
-        fstat = ::File::Stat.new(fname)
-        fdata.push [
-          permission_convert(fstat),
-          fstat.nlink.to_s.rjust(nlink_length(files)),
-          Etc.getpwuid(fstat.uid).name,
-          Etc.getgrgid(fstat.gid).name.rjust(6),
-          fstat.size.to_s.rjust(5),
-          fstat.mtime.strftime('%_m %e %H:%M'),
-          fname
+      file_data = []
+      files.each do |file_name|
+        file_stat = ::File::Stat.new(file_name)
+        file_data.push [
+          permission_convert(file_stat),
+          file_stat.nlink.to_s.rjust(nlink_length(files)),
+          Etc.getpwuid(file_stat.uid).name,
+          Etc.getgrgid(file_stat.gid).name.rjust(6),
+          file_stat.size.to_s.rjust(5),
+          file_stat.mtime.strftime('%_m %e %H:%M'),
+          file_name
         ]
       end
-      fdata
+      file_data
     end
 
     private
 
     def nlink_length(files)
       max_length = []
-      files.each do |fname|
-        fstat = ::File::Stat.new(fname)
-        max_length << fstat.nlink
+      files.each do |file_name|
+        file_stat = ::File::Stat.new(file_name)
+        max_length << file_stat.nlink
       end
       max_length.max_by { |num| num.to_s.length }.to_s.length
     end
 
-    def permission_convert(fstat)
-      type = fstat.ftype == 'file' ? '-' : fstat.ftype[0]
+    def permission_convert(file_stat)
+      type = file_stat.ftype == 'file' ? '-' : file_stat.ftype[0]
       rwx = { '0' => '---', '1' => '--x', '2' => '-w-', '3' => '-wx',
               '4' => 'r--', '5' => 'r-x', '6' => 'rw-', '7' => 'rwx' }
-      mode = fstat.mode.to_s(8)[-3, 3].gsub(/\d/, rwx)
+      mode = file_stat.mode.to_s(8)[-3, 3].gsub(/\d/, rwx)
       "#{type}#{mode} "
     end
   end
@@ -89,9 +89,9 @@ module LS
   class HorizontalFormatter
     def multi_column(files)
       result = []
-      files.map { |fname| result << fname.to_s.ljust(24, ' ') }
+      files.map { |file_name| result << file_name.to_s.ljust(24, ' ') }
       format = result.each_slice(length(files)).to_a
-      push_nil(format).transpose.each { |a| puts a.join('') }
+      push_nil(format).transpose.each { |array| puts array.join('') }
     end
 
     private
@@ -102,24 +102,24 @@ module LS
 
     def push_nil(format)
       max = format.max_by(&:length).length
-      format.each { |a| a[max - 1] = nil if a.length < max }
+      format.each { |array| array[max - 1] = nil if array.length < max }
     end
   end
 
   class VerticalFormatter
     def total(files)
       total = 0
-      files.each do |fname|
-        fstat = ::File::Stat.new(fname)
-        total += fstat.blocks
+      files.each do |file_name|
+        file_stat = ::File::Stat.new(file_name)
+        total += file_stat.blocks
       end
       puts "total #{total}"
     end
 
     def single_column(files)
       total(files)
-      fdata = LS::Command.new.data(files)
-      fdata.map { |a| puts a.each_slice(7).to_a.join(' ') }
+      file_data = LS::Command.new.data(files)
+      file_data.map { |array| puts array.each_slice(7).to_a.join(' ') }
     end
   end
 end

--- a/08.ls_object/ls.rb
+++ b/08.ls_object/ls.rb
@@ -56,47 +56,51 @@ module Ls
   end
 
   class VerticalFormatter
-    def self.output_single_column(files)
-      puts "total #{total(files)}"
-      file_details(files).each { |array| puts array.each_slice(7).to_a.join(' ') }
-    end
-
-    def self.total(files)
-      files.sum do |file_name|
-        file_stat = ::File::Stat.new(file_name)
-        file_stat.blocks
+    class << self
+      def output_single_column(files)
+        puts "total #{total(files)}"
+        file_details(files).each { |array| puts array.each_slice(7).to_a.join(' ') }
       end
-    end
 
-    def self.file_details(files)
-      files.map do |file_name|
-        file_stat = ::File::Stat.new(file_name)
-        [
-          permission_convert(file_stat),
-          file_stat.nlink.to_s.rjust(nlink_length(files)),
-          Etc.getpwuid(file_stat.uid).name,
-          Etc.getgrgid(file_stat.gid).name.rjust(6),
-          file_stat.size.to_s.rjust(5),
-          file_stat.mtime.strftime('%_m %e %H:%M'),
-          file_name
-        ]
+      private
+
+      def total(files)
+        files.sum do |file_name|
+          file_stat = ::File::Stat.new(file_name)
+          file_stat.blocks
+        end
       end
-    end
 
-    def self.nlink_length(files)
-      max_length = files.map do |file_name|
-        file_stat = ::File::Stat.new(file_name)
-        file_stat.nlink
+      def file_details(files)
+        files.map do |file_name|
+          file_stat = ::File::Stat.new(file_name)
+          [
+            permission_convert(file_stat),
+            file_stat.nlink.to_s.rjust(nlink_length(files)),
+            Etc.getpwuid(file_stat.uid).name,
+            Etc.getgrgid(file_stat.gid).name.rjust(6),
+            file_stat.size.to_s.rjust(5),
+            file_stat.mtime.strftime('%_m %e %H:%M'),
+            file_name
+          ]
+        end
       end
-      max_length.max_by { |number| number.to_s.length }.to_s.length
-    end
 
-    def self.permission_convert(file_stat)
-      type = file_stat.ftype == 'file' ? '-' : file_stat.ftype[0]
-      rwx = { '0' => '---', '1' => '--x', '2' => '-w-', '3' => '-wx',
-              '4' => 'r--', '5' => 'r-x', '6' => 'rw-', '7' => 'rwx' }
-      mode = file_stat.mode.to_s(8)[-3, 3].gsub(/\d/, rwx)
-      "#{type}#{mode} "
+      def nlink_length(files)
+        max_length = files.map do |file_name|
+          file_stat = ::File::Stat.new(file_name)
+          file_stat.nlink
+        end
+        max_length.max_by { |number| number.to_s.length }.to_s.length
+      end
+
+      def permission_convert(file_stat)
+        type = file_stat.ftype == 'file' ? '-' : file_stat.ftype[0]
+        rwx = { '0' => '---', '1' => '--x', '2' => '-w-', '3' => '-wx',
+                '4' => 'r--', '5' => 'r-x', '6' => 'rw-', '7' => 'rwx' }
+        mode = file_stat.mode.to_s(8)[-3, 3].gsub(/\d/, rwx)
+        "#{type}#{mode} "
+      end
     end
   end
 end

--- a/08.ls_object/ls.rb
+++ b/08.ls_object/ls.rb
@@ -26,10 +26,9 @@ module Ls
     end
 
     def file_details(files)
-      file_data = []
-      files.each do |file_name|
+      files.map do |file_name|
         file_stat = ::File::Stat.new(file_name)
-        file_data.push [
+        [
           permission_convert(file_stat),
           file_stat.nlink.to_s.rjust(nlink_length(files)),
           Etc.getpwuid(file_stat.uid).name,
@@ -39,7 +38,6 @@ module Ls
           file_name
         ]
       end
-      file_data
     end
 
     def excute

--- a/08.ls_object/ls.rb
+++ b/08.ls_object/ls.rb
@@ -70,15 +70,15 @@ module Ls
     end
 
     def select_option
-      if options[:a] == true
+      if options[:a]
         @files = all(files)
       else
         @files
       end
 
-      @files = reverse(files) if options[:r] == true
+      @files = reverse(files) if options[:r]
 
-      if options[:l] == true
+      if options[:l]
         Ls::VerticalFormatter.new.single_column(@files)
       else
         Ls::HorizontalFormatter.new.multi_column(@files)

--- a/08.ls_object/ls.rb
+++ b/08.ls_object/ls.rb
@@ -5,7 +5,7 @@ require 'etc'
 
 module Ls
   class Command
-    attr_reader :options
+    attr_reader :options, :files
 
     def initialize
       @options = {}
@@ -14,18 +14,15 @@ module Ls
       option.on('-l', '--long') { |value| @options[:l] = value }
       option.on('-r', '--reverse') { |value| @options[:r] = value }
       option.parse(ARGV)
+      @files = Dir.glob('*').sort
     end
 
-    def files
-      Dir.glob('*').sort
+    def all_files
+      Dir.glob('.*').sort + @files
     end
 
-    def all(files)
-      Dir.glob('.*').sort + files
-    end
-
-    def reverse(files)
-      files.reverse
+    def reverse_files
+      @files.reverse
     end
 
     def data(files)
@@ -46,8 +43,8 @@ module Ls
     end
 
     def excute
-      @files = (options[:a] ? all(files) : files)
-      @files = reverse(@files) if options[:r]
+      @files = all_files if options[:a]
+      @files = reverse_files if options[:r]
       if options[:l]
         Ls::VerticalFormatter.new.output_single_column(@files)
       else

--- a/08.ls_object/ls.rb
+++ b/08.ls_object/ls.rb
@@ -71,8 +71,7 @@ module Ls
 
   class HorizontalFormatter
     def output_multi_column(files)
-      results = []
-      files.map { |file| results << file.to_s.ljust(24, ' ') }
+      results = files.map { |file| file.to_s.ljust(24, ' ') }
       file_names = results.each_slice(length(files)).to_a
       push_nil(file_names).transpose.each { |array| puts array.join('') }
     end

--- a/08.ls_object/ls.rb
+++ b/08.ls_object/ls.rb
@@ -44,7 +44,7 @@ module Ls
         file_stat = ::File::Stat.new(file_name)
         max_length << file_stat.nlink
       end
-      max_length.max_by { |num| num.to_s.length }.to_s.length
+      max_length.max_by { |number| number.to_s.length }.to_s.length
     end
 
     def permission_convert(file_stat)

--- a/08.ls_object/ls.rb
+++ b/08.ls_object/ls.rb
@@ -113,11 +113,11 @@ module Ls
         file_stat = ::File::Stat.new(file_name)
         total += file_stat.blocks
       end
-      puts "total #{total}"
+      "total #{total}"
     end
 
     def single_column(files)
-      total(files)
+      puts total(files)
       file_data = Ls::Command.new.data(files)
       file_data.map { |array| puts array.each_slice(7).to_a.join(' ') }
     end

--- a/08.ls_object/ls.rb
+++ b/08.ls_object/ls.rb
@@ -89,9 +89,9 @@ module Ls
   class HorizontalFormatter
     def output_multi_column(files)
       results = []
-      files.map { |file_name| results << file_name.to_s.ljust(24, ' ') }
-      format = results.each_slice(length(files)).to_a
-      push_nil(format).transpose.each { |array| puts array.join('') }
+      files.map { |file| results << file.to_s.ljust(24, ' ') }
+      file_names = results.each_slice(length(files)).to_a
+      push_nil(file_names).transpose.each { |array| puts array.join('') }
     end
 
     private

--- a/08.ls_object/ls.rb
+++ b/08.ls_object/ls.rb
@@ -5,7 +5,7 @@ require 'etc'
 
 module Ls
   class Command
-    attr_reader :options, :files
+    attr_reader :options
 
     def initialize
       @options = {}

--- a/08.ls_object/ls.rb
+++ b/08.ls_object/ls.rb
@@ -53,10 +53,9 @@ module Ls
     private
 
     def nlink_length(files)
-      max_length = []
-      files.each do |file_name|
+      max_length = files.map do |file_name|
         file_stat = ::File::Stat.new(file_name)
-        max_length << file_stat.nlink
+        file_stat.nlink
       end
       max_length.max_by { |number| number.to_s.length }.to_s.length
     end

--- a/08.ls_object/ls.rb
+++ b/08.ls_object/ls.rb
@@ -62,11 +62,11 @@ module LS
     def initialize
       super
       @options = {}
-      opt = OptionParser.new
-      opt.on('-a', '--all') { |v| @options[:a] = v }
-      opt.on('-l', '--long') { |v| @options[:l] = v }
-      opt.on('-r', '--reverse') { |v| @options[:r] = v }
-      opt.parse(ARGV)
+      option = OptionParser.new
+      option.on('-a', '--all') { |value| @options[:a] = value }
+      option.on('-l', '--long') { |value| @options[:l] = value }
+      option.on('-r', '--reverse') { |value| @options[:r] = value }
+      option.parse(ARGV)
     end
 
     def select_option

--- a/08.ls_object/ls.rb
+++ b/08.ls_object/ls.rb
@@ -81,13 +81,13 @@ module Ls
       if options[:l]
         Ls::VerticalFormatter.new.output_single_column(@files)
       else
-        Ls::HorizontalFormatter.new.multi_column(@files)
+        Ls::HorizontalFormatter.new.output_multi_column(@files)
       end
     end
   end
 
   class HorizontalFormatter
-    def multi_column(files)
+    def output_multi_column(files)
       result = []
       files.map { |file_name| result << file_name.to_s.ljust(24, ' ') }
       format = result.each_slice(length(files)).to_a

--- a/08.ls_object/ls.rb
+++ b/08.ls_object/ls.rb
@@ -69,7 +69,7 @@ module Ls
       option.parse(ARGV)
     end
 
-    def select_option
+    def excute
       if options[:a]
         @files = all(files)
       else
@@ -124,4 +124,4 @@ module Ls
   end
 end
 
-Ls::Command.new.select_option
+Ls::Command.new.excute

--- a/08.ls_object/ls.rb
+++ b/08.ls_object/ls.rb
@@ -79,7 +79,7 @@ module Ls
       @files = reverse(files) if options[:r]
 
       if options[:l]
-        Ls::VerticalFormatter.new.single_column(@files)
+        Ls::VerticalFormatter.new.output_single_column(@files)
       else
         Ls::HorizontalFormatter.new.multi_column(@files)
       end
@@ -116,7 +116,7 @@ module Ls
       "total #{total}"
     end
 
-    def single_column(files)
+    def output_single_column(files)
       puts total(files)
       file_data = Ls::Command.new.data(files)
       file_data.map { |array| puts array.each_slice(7).to_a.join(' ') }

--- a/08.ls_object/ls.rb
+++ b/08.ls_object/ls.rb
@@ -65,8 +65,7 @@ module Ls
 
     def output_single_column(files)
       puts "total #{total(files)}"
-      file_data = file_details(files)
-      file_data.map { |array| puts array.each_slice(7).to_a.join(' ') }
+      file_details(files).each { |array| puts array.each_slice(7).to_a.join(' ') }
     end
 
     def file_details(files)

--- a/08.ls_object/ls.rb
+++ b/08.ls_object/ls.rb
@@ -25,7 +25,7 @@ module Ls
       @files.reverse
     end
 
-    def data(files)
+    def file_details(files)
       file_data = []
       files.each do |file_name|
         file_stat = ::File::Stat.new(file_name)
@@ -102,7 +102,7 @@ module Ls
 
     def output_single_column(files)
       puts "total #{total(files)}"
-      file_data = Ls::Command.new.data(files)
+      file_data = Ls::Command.new.file_details(files)
       file_data.map { |array| puts array.each_slice(7).to_a.join(' ') }
     end
   end

--- a/08.ls_object/ls.rb
+++ b/08.ls_object/ls.rb
@@ -88,9 +88,9 @@ module Ls
 
   class HorizontalFormatter
     def output_multi_column(files)
-      result = []
-      files.map { |file_name| result << file_name.to_s.ljust(24, ' ') }
-      format = result.each_slice(length(files)).to_a
+      results = []
+      files.map { |file_name| results << file_name.to_s.ljust(24, ' ') }
+      format = results.each_slice(length(files)).to_a
       push_nil(format).transpose.each { |array| puts array.join('') }
     end
 


### PR DESCRIPTION
## 内容
オブジェクト指向版のlsコマンドを作成を作成しました。
- LinuxコマンドのlsコマンドをRubyで作成する。
- `-a` `-l` `-r`オプションを実装する。
- `-alr`でも`-lra`でも`-ral`でも順番に関係なく実行できる。
- `rubocop-fjord`をパスさせる。

## Terminalの実行結果
### オプションなし
<img width="621" alt="スクリーンショット 2021-03-08 7 18 52" src="https://user-images.githubusercontent.com/53958282/110331861-faee3e80-8062-11eb-854d-7fdd967a7d36.png">

### -aオプション
<img width="621" alt="スクリーンショット 2021-03-08 7 19 30" src="https://user-images.githubusercontent.com/53958282/110331905-07729700-8063-11eb-9fc6-735df5d20108.png">

### -rオプション
<img width="621" alt="スクリーンショット 2021-03-08 7 20 06" src="https://user-images.githubusercontent.com/53958282/110331932-0fcad200-8063-11eb-8af7-27fa4e055b1e.png">

### -lオプション
<img width="621" alt="スクリーンショット 2021-03-08 7 20 41" src="https://user-images.githubusercontent.com/53958282/110331942-135e5900-8063-11eb-9355-397437de50ea.png">

### -alrオプション
<img width="621" alt="スクリーンショット 2021-03-08 7 21 27" src="https://user-images.githubusercontent.com/53958282/110331964-1a856700-8063-11eb-8fbe-9f68ed70a242.png"> 

<img width="621" alt="スクリーンショット 2021-03-08 7 36 03" src="https://user-images.githubusercontent.com/53958282/110332019-2a04b000-8063-11eb-8323-d62eeae33ba0.png">
